### PR TITLE
Apply various improvements.

### DIFF
--- a/draft-irtf-cfrg-spake2.xml
+++ b/draft-irtf-cfrg-spake2.xml
@@ -58,14 +58,14 @@
         appear in all capitals, as shown here.</t>
     </section>
     <section anchor="definition" title="Definition of SPAKE2">
-      <section title="Setup">
+      <section title="Setup" anchor="setup">
         <t>Let G be a group in which the computational Diffie-Hellman (CDH)
           problem is hard. Suppose G has order p*h where p is a large prime;
           h will be called the cofactor. Let I be the unit element in
           G, e.g., the point at infinity if G is an elliptic curve group. We denote the
           operations in the group additively. We assume there is a representation of
           elements of G as byte strings: common choices would be SEC1
-          compressed <xref target="SEC1" /> for elliptic curve groups or big
+          uncompressed or compressed <xref target="SEC1" /> for elliptic curve groups or big
           endian integers of a fixed (per-group) length for prime field DH.
           We fix two elements M and N in the prime-order subgroup of G as defined
           in the table in this document for common groups, as well as a generator P
@@ -87,7 +87,7 @@
           hash function designed to slow down brute-force attackers. Scrypt <xref target="RFC7914"/>
           is a common example of this function. The output length of MHF matches that
           of Hash. Parameter selection for MHF is out of scope for this document.
-          <xref target="Ciphersuites"/> specifies variants of KDF, MAC, Hash, and MHF
+          <xref target="Ciphersuites"/> specifies variants of KDF, MAC, and Hash
           suitable for use with the protocols contained herein.</t>
 
         <t>Let A and B be two parties. A and B may also have digital
@@ -112,19 +112,49 @@
           same password with both protocols; passwords MUST NOT be used for
           both SPAKE2 and SPAKE2+.</t>
       </section>
+
+      <section title="Protocol Flow" anchor="flow">
+        <t>Both SPAKE2 and SPAKE2+ are one round protocols to establish a shared secret with an 
+          additional round for key confirmation. Prior to invocation, A and B are provisioned with
+          information such as the input password needed to run the protocol. 
+          During the first round, A sends a public share pA 
+          to B, and B responds with its own public share pB. Both A and B then derive a shared secret
+          used to produce encryption and authentication keys. The latter are used during the second
+          round for key confirmation. (<xref target="keys"/> details the key derivation and 
+          confirmation steps.) In particular, A sends a key confirmation message cA to B, and B responds
+          with its own key confirmation messgage cB. Both parties MUST NOT consider the protocol complete
+          prior to receipt and validation of these key confirmation messages.</t>
+
+        <t>This sample trace is shown below.</t>
+        <figure><artwork><![CDATA[
+                A                  B
+                | (setup protocol) |
+  (compute pA)  |        pA        |
+                |----------------->|
+                |        pB        | (compute pB)
+                |<-----------------|
+                |                  | 
+                | (derive secrets) |
+  (compute cA)  |        cA        |
+                |----------------->|
+                |        cB        | (compute cB)
+                |<-----------------|
+        ]]></artwork></figure>
+      </section>
+
       <section title="SPAKE2" anchor="spake2">
         <t>To begin, A picks x randomly and uniformly from the integers in [0,p),
-            and calculates X=x*P and T=w*M+X, then transmits T to B.</t>
+            and calculates X=x*P and T=w*M+X, then transmits pA=T to B.</t>
 
         <t>B selects y randomly and uniformly from the integers in [0,p), and calculates
-            Y=y*P, S=w*N+Y, then transmits S to A.</t>
+            Y=y*P, S=w*N+Y, then transmits pB=S to A.</t>
 
         <t>Both A and B calculate a group element K. A calculates it
         as h*x*(S-wN), while B calculates it as h*y*(T-w*M). A knows S
         because it has received it, and likewise B knows T. The
         multiplication by h prevents small subgroup confinement
         attacks by computing a unique value in the quotient
-        group. (Any text on abstract algebra explains this notion)</t>
+        group. (Any text on abstract algebra explains this notion.)</t>
 
         <t>K is a shared value, though it MUST NOT be used as a shared secret.
           Both A and B must derive two shared secrets from K and the protocol transcript.
@@ -132,8 +162,8 @@
           the exchange. The transcript TT is encoded as follows:</t>
 
         <figure><artwork><![CDATA[
-	TT = len(A) || A || len(B) || B || len(S) || S || len(T) || T
-             || len(K) || K || len(w) || w
+	TT = len(A) || A || len(B) || B || len(S) || S 
+          || len(T) || T || len(K) || K || len(w) || w
         ]]></artwork></figure>
 
         <t>If an identity is absent, it is omitted from the transcript entirely. For example,
@@ -141,7 +171,7 @@
           Likewise, if only A is absent, TT = len(B) || B || len(S) || S || len(T) || T || len(K) || K || len(w) || w.
           This must only be done for applications in which identities are implicit. Otherwise,
           the protocol risks Unknown Key Share attacks (discussion of Unknown Key Share attacks
-          in a specific protocl is given in <xref target="I-D.ietf-mmusic-sdp-uks"/>.</t>
+          in a specific protocol is given in <xref target="I-D.ietf-mmusic-sdp-uks"/>.</t>
 
         <t>Upon completion of this protocol, A and B compute shared secrets Ke, KcA, and KcB as
             specified in <xref target="keys"/>. A MUST send B a key confirmation message
@@ -159,6 +189,8 @@
           participants, A and B. Specifically,
           w0s || w1s = MHF(len(pw) || pw || len(A) || A || len(B) || B),
           and then computing w0 = w0s mod p and w1 = w1s mod p.
+          If both identities A and B are absent, then w0s || w1s = MHF(pw), i.e.,
+          the length prefix is omitted as in <xref target="setup"/>.
           The length of each of w0s and w1s is equal to half of the MHF output, e.g.,
           |w0s| = |w1s| = 128 bits for scrypt.
           w0 and w1 MUST NOT equal I. If they are,
@@ -168,10 +200,10 @@
           valid w0 and w1 are produced. B stores L=w1*P and w0.</t>
 
         <t>When executing SPAKE2+, A selects x uniformly at random from the
-          numbers in the range [0, p), and lets X=x*P+w0*M, then transmits X to
+          numbers in the range [0, p), and lets X=x*P+w0*M, then transmits pA=X to
           B. Upon receipt of X, A computes h*X and aborts if the result is equal
           to I. B then selects y uniformly at random from the numbers in [0, p),
-          then computes Y=y*P+w0*N, and transmits Y to A. .</t>
+          then computes Y=y*P+w0*N, and transmits pB=Y to A. .</t>
 
         <t>A computes Z as h*x*(Y-w0*N), and V as h*w1*(Y-w0*N). B computes Z as h*y*(X-
           w0*M) and V as h*y*L. Both share Z and V as common keys. It is essential
@@ -179,8 +211,9 @@
           derive the keying material. The protocol transcript encoding is shown below.</t>
 
         <figure><artwork><![CDATA[
-            TT = len(A) || A || len(B) || B || len(X) || X || len(Y) || Y
-             || len(Z) || Z || len(V) || V || len(w0) || w0
+            TT = len(A) || A || len(B) || B || len(X) || X 
+              || len(Y) || Y || len(Z) || Z || len(V) || V 
+              || len(w0) || w0
         ]]></artwork></figure>
 
         <t>As in <xref target="spake2"/>, inclusion of A and B in the transcript is optional depending
@@ -207,7 +240,7 @@
             data AAD, is as follows.</t>
 
         <figure><artwork><![CDATA[
-        TT   -> Hash(TT) = Ke || Ka
+        TT  -> Hash(TT) = Ka || Ke
         AAD -> KDF(nil, Ka, "ConfirmationKeys" || AAD) = KcA || KcB
         ]]></artwork></figure>
 
@@ -227,70 +260,60 @@
                 <ttcol align='center'>Hash</ttcol>
                 <ttcol align='center'>KDF</ttcol>
                 <ttcol align='center'>MAC</ttcol>
-                <ttcol align='center'>MHF</ttcol>
 
                 <!-- P256-SHA256-HKDF-HMAC -->
                 <c>P-256</c>
                 <c>SHA256 <xref target="RFC6234"/></c>
                 <c>HKDF <xref target="RFC5869"/></c>
                 <c>HMAC <xref target="RFC2104"/></c>
-                <c>scrypt <xref target="RFC7914"/></c>
 
                 <!-- P256-SHA512-HKDF-HMAC -->
                 <c>P-256</c>
                 <c>SHA512 <xref target="RFC6234"/></c>
                 <c>HKDF <xref target="RFC5869"/></c>
                 <c>HMAC <xref target="RFC2104"/></c>
-                <c>scrypt <xref target="RFC7914"/></c>
 
                 <!-- P384-SHA256-HKDF-HMAC -->
                 <c>P-384</c>
                 <c>SHA256 <xref target="RFC6234"/></c>
                 <c>HKDF <xref target="RFC5869"/></c>
                 <c>HMAC <xref target="RFC2104"/></c>
-                <c>scrypt <xref target="RFC7914"/></c>
 
                 <!-- P384-SHA512-HKDF-HMAC -->
                 <c>P-384</c>
                 <c>SHA512 <xref target="RFC6234"/></c>
                 <c>HKDF <xref target="RFC5869"/></c>
                 <c>HMAC <xref target="RFC2104"/></c>
-                <c>scrypt <xref target="RFC7914"/></c>
 
                 <!-- P512-SHA512-HKDF-HMAC -->
                 <c>P-512</c>
                 <c>SHA512 <xref target="RFC6234"/></c>
                 <c>HKDF <xref target="RFC5869"/></c>
                 <c>HMAC <xref target="RFC2104"/></c>
-                <c>scrypt <xref target="RFC7914"/></c>
 
                 <!-- edwards25519-SHA256-HKDF-HMAC -->
                 <c>edwards25519 <xref target="RFC7748"/></c>
                 <c>SHA256 <xref target="RFC6234"/></c>
                 <c>HKDF <xref target="RFC5869"/></c>
                 <c>HMAC <xref target="RFC2104"/></c>
-                <c>scrypt <xref target="RFC7914"/></c>
 
                 <!-- edwards448-SHA512-HKDF-HMAC -->
                 <c>edwards448 <xref target="RFC7748"/></c>
                 <c>SHA512 <xref target="RFC6234"/></c>
                 <c>HKDF <xref target="RFC5869"/></c>
                 <c>HMAC <xref target="RFC2104"/></c>
-                <c>scrypt <xref target="RFC7914"/></c>
 
                 <!-- P256-SHA256-HKDF-CMAC -->
                 <c>P-256</c>
                 <c>SHA256 <xref target="RFC6234"/></c>
                 <c>HKDF <xref target="RFC5869"/></c>
                 <c>CMAC-AES-128 <xref target="RFC4493"/></c>
-                <c>scrypt <xref target="RFC7914"/></c>
 
                 <!-- P256-SHA512-HKDF-CMAC -->
                 <c>P-256</c>
                 <c>SHA512 <xref target="RFC6234"/></c>
                 <c>HKDF <xref target="RFC5869"/></c>
                 <c>CMAC-AES-128 <xref target="RFC4493"/></c>
-                <c>scrypt <xref target="RFC7914"/></c>
             </texttable>
 
         <t>The following points represent permissible point generation seeds
@@ -532,6 +555,278 @@ def gen_point(seed, ecname, ec):
         except Exception:
             pass
 ]]></artwork></figure>
+    </section>
+
+    <section anchor="testvectors" title="Test Vectors">
+      <t>This section contains test vectors for SPAKE2 and SPAKE2+ using 
+        the P256-SHA256-HKDF-HMAC ciphersuite. (Choice of MHF is omitted
+        and values for w and w0,w1 are provided directly.) All points are 
+        encoded using the uncompressed format, i.e., with a 0x04 octet
+        prefix, specified in <xref target="SEC1"/> A and B identity strings
+        are provided in the protocol invocation.
+      </t>
+
+      <section title="SPAKE2 Test Vectors">
+        <figure><artwork><![CDATA[
+SPAKE2(A='client', B='server') 
+w = 0x7741cf8c80b9bee583abac3d38daa6b807fed38b06580cb75ee85319d25fed
+e6 
+X = 0x04ac6827b3a9110d1e663bcd4f5de668da34a9f45e464e99067bbea53f1ed4
+d8abbdd234c05b3a3a8a778ee47f244cca1a79acb7052d5e58530311a9af077ba179
+T = 0x04e02acfbbfb081fc38b5bab999b5e25a5ffd0b1ac48eae24fcc8e49ac5e0d
+8a790914419a100e205605f9862daa848e99cea455263f0c6e06bc5a911f3e10a16b
+Y = 0x0413c45ab093a75c4b2a6e71f957eec3859807858325258b0fa43df5a6efd2
+63c59b9c1fbfd55bc5e75fd3e7ba8af6799a99b225fe6c30e6c2a2e0ab4962136ba8
+S = 0x047aad50ba7bd6a5eacbead7689f7146f1a4219fa071cce1755f80280cc6c3
+a5a73cf469f2a294a0b74a5c07054585ccd447f3f633d8631f3bf43442449e9efeba
+TT = 0x0600000000000000636c69656e74060000000000000073657276657241000
+00000000000047aad50ba7bd6a5eacbead7689f7146f1a4219fa071cce1755f80280
+cc6c3a5a73cf469f2a294a0b74a5c07054585ccd447f3f633d8631f3bf43442449e9
+efeba410000000000000004e02acfbbfb081fc38b5bab999b5e25a5ffd0b1ac48eae
+24fcc8e49ac5e0d8a790914419a100e205605f9862daa848e99cea455263f0c6e06b
+c5a911f3e10a16b410000000000000004d01fc08bbae9b6abe2f4d6893cc9f810433
+2e19be5f5881c6b9f077e1feff55023da74db65fae320fad8f0dd38e1323f5336f3f
+53c9c9dec06710f18f556bd2020000000000000007741cf8c80b9bee583abac3d38d
+aa6b807fed38b06580cb75ee85319d25fede6 
+Ka = 0x2b5e350c58d530c3586f75bf2a155c4b 
+Ke = 0x238509f7adf0dc72500b2d1315737a27 
+KcA = 0xc33d2ef8e37a7e545c14c7fcfdc9db94 
+KcB = 0x18a81cec7eb83416db6615cb3bc03fcb 
+MAC(A) = 0x29e9a63d243f2f0db5532d2eb0dbaa617803b85feb31566d0cb9457e3
+03bcfa6 
+MAC(B) = 0x487e4cbe98b6287272d043e169a19b6c4682d0481c92f53f1ee03d4b8
+6c3f43e 
+
+SPAKE2(A='client', B='') 
+w = 0x7741cf8c80b9bee583abac3d38daa6b807fed38b06580cb75ee85319d25fed
+e6 
+X = 0x048b5d7b44b02c4c868f4486ec55bd2380ec34cd5fa5dbff1079a79097e305
+0b34fa91272331729357c86cbb30d371e252dc915aeaa314921b1f09f74816f96a12
+T = 0x04839f44931b88d12769e601d0ec480b6c9ea95e70ba361ba14bf513e5186a
+6c302e6f409bd01f1030ad3cdac1e08965217e430ca7f9bce698111ae8a4d0530efd
+Y = 0x0446419d63037d0bbaca224f89987c776bfea2e0913ccda0790079212f476d
+6fd1ec997a02821a804f885e4f29b172b27c92251d883efe201cae106c239108c0c7
+S = 0x042926b2dbcc5d0cb23ca123cc4133242f2998439af5380434a4bd5fd76fbb
+c030b5563218d0184fa3fd303482a679c9555ccea41098b26b6ee16fe35c792b1fda
+TT = 0x0600000000000000636c69656e744100000000000000042926b2dbcc5d0cb
+23ca123cc4133242f2998439af5380434a4bd5fd76fbbc030b5563218d0184fa3fd3
+03482a679c9555ccea41098b26b6ee16fe35c792b1fda410000000000000004839f4
+4931b88d12769e601d0ec480b6c9ea95e70ba361ba14bf513e5186a6c302e6f409bd
+01f1030ad3cdac1e08965217e430ca7f9bce698111ae8a4d0530efd4100000000000
+000041d9e3c88db68247ab50264a6090e2e524bda3049dbc53c4df708e37bd76913b
+8cf5954c4d0f835331f185fef4ff1c6115cf0eb8ce27e8224bf5f76c75b182308200
+00000000000007741cf8c80b9bee583abac3d38daa6b807fed38b06580cb75ee8531
+9d25fede6 
+Ka = 0xfc8482d5d7623a75ad09721d631d1392 
+Ke = 0x93f618fe24d0d5a54b320f498dbd3ecb 
+KcA = 0x75b20fc4205d6217a22156f918dd03b1 
+KcB = 0x3bf3a5d3876d9d12dc54cab927acd5f7 
+MAC(A) = 0xd4994b751eb832b2836ad674cd615c643053278864a63e263bc2f324b
+9a04ddd 
+MAC(B) = 0x23cf761999b7603adf5507b50c9bda4eaabe8fa7a9ad0280729dfcd00
+8b2bf05 
+
+SPAKE2(A='', B='server') 
+w = 0x7741cf8c80b9bee583abac3d38daa6b807fed38b06580cb75ee85319d25fed
+e6 
+X = 0x0465e8b4709ba622bc97af5dde3b41757c2114bfc5abb10141245cb01d62ca
+0d7360e1169cd518f9351bbfa44a66cc5f3bcb60661a04f39b04a3d504046db67884
+T = 0x0482f64286419ff46362faf781776edf908740b8ff612e0bfe3c90cdc553ba
+db7f882a4110ee71fa13a693b5ce96ceba5798636555d074648d4521e3b63dc14872
+Y = 0x041aa11299692627a7cac122d4c14606ff700a8be6a0fb1c42f3762d629893
+ab3ca51e4a48c798fc8c6b9dcfda1ad33099ed2f73abe6b3500ce383f54011430c26
+S = 0x04adba3c3b9a74d9769651d09aedb37d22b9471b9e408e2b98fdd4188c12fa
+c731e9dc87e029f7dee0213660ddf0791f50dd8fd32f7152015be0489125b3831b4b
+TT = 0x0600000000000000736572766572410000000000000004adba3c3b9a74d97
+69651d09aedb37d22b9471b9e408e2b98fdd4188c12fac731e9dc87e029f7dee0213
+660ddf0791f50dd8fd32f7152015be0489125b3831b4b41000000000000000482f64
+286419ff46362faf781776edf908740b8ff612e0bfe3c90cdc553badb7f882a4110e
+e71fa13a693b5ce96ceba5798636555d074648d4521e3b63dc148724100000000000
+00004a406929024a5275372531c85c54fd222f35bfdb1cdf1bd1abe82d5c837744d9
+3ea2979962eb374d4feda37b178e91711c52edd453178cf69748e0a3d9ef073c2200
+00000000000007741cf8c80b9bee583abac3d38daa6b807fed38b06580cb75ee8531
+9d25fede6 
+Ka = 0xcd9c33c6329761919486d0041faccb56 
+Ke = 0xa08125eeed51c61ad93b2ff7d8ec3cd5 
+KcA = 0x60056386cbe06ba199fa6aef81dfb273 
+KcB = 0x5e5a591b4426d47190aecb2fc4527140 
+MAC(A) = 0xf0dcfb4fa874e3fcbadd44b6eb26a64d1d5c6e50034934934551f172d
+3cdc50e 
+MAC(B) = 0x52e7a505c0b73db656108554a854c3f33bfb01edcc1ee52aa27ceb1cb
+ef7f47b 
+
+SPAKE2(A='', B='') 
+w = 0x7741cf8c80b9bee583abac3d38daa6b807fed38b06580cb75ee85319d25fed
+e6 
+X = 0x04fbeb44d6b772fa390fcced51be7316107e608ddf4ab5dcc9f1b2e24bf667
+7f3232cdeeb39a61621a9e48028997d449894212eb54b6f12bdbd9baf8f1c909a740
+T = 0x04887af8439d743215f26d48314835b024b9301ea508eac3a339241672fbba
+09f63e155b1df5d31ccc63babafc00ffff6e258c692aed84a859fd4960d99fcec777
+Y = 0x04bb4727c5c5c50ae34d5148ec6797e5ebf93ae51c5c6cfd48579c41436823
+1ac8769142bf6a0109bd2b86dd901c6054629ce2c6b982326c9cd9a3685c4cf0640d
+S = 0x04665b5101132528be32f4b4762d6ae80273bbe74e151fc2320da373e146ee
+cd33038ff8099782f3781160244672cb43b4d9f2007da9b617c1890845440da0ca53
+TT = 0x410000000000000004665b5101132528be32f4b4762d6ae80273bbe74e151
+fc2320da373e146eecd33038ff8099782f3781160244672cb43b4d9f2007da9b617c
+1890845440da0ca53410000000000000004887af8439d743215f26d48314835b024b
+9301ea508eac3a339241672fbba09f63e155b1df5d31ccc63babafc00ffff6e258c6
+92aed84a859fd4960d99fcec777410000000000000004aacd2378990cecd338c7cac
+d132ce633bc424ac5d4ab32f539ccf31f15deef62463253790e139b461c5137944fc
+6a5ffd895dbe0d3960b01f6d662fc41057a7020000000000000007741cf8c80b9bee
+583abac3d38daa6b807fed38b06580cb75ee85319d25fede6 
+Ka = 0x16b10f1541c24c630f462f7e0aa57ddf 
+Ke = 0xb7ae8b61938e3dfad8b9ce1d2865533f 
+KcA = 0x3398d6c7de402a9ae89a4594d5576c21 
+KcB = 0x6894ab44d7ba7f3a40a772d1476593d9 
+MAC(A) = 0x12fce7f0aecc1dba393a7e5612e6357becc5e3d07cd41ffd35c6d652f
+29cde60 
+MAC(B) = 0xac36c6d186c3b824f4cfe099f035cf3aed4162d08886d32fa1806e5bf
+4015255 
+    ]]></artwork></figure>
+      </section>
+
+      <section title="SPAKE2+ Test Vectors">
+<figure><artwork><![CDATA[
+SPAKE2+(A='client', B='server') 
+w0 = 0x4f9e28322a64f9dc7a01b282cc51e2abc4f9ed568805ca84f4ed3ef806516
+cf8 
+w1 = 0x8d73e4ca273859c873d809431d15f30e2b722007964e32699160b54fda3ee
+855 
+L = 0x0491bb1e6672e71ad80b17d13f7a72ca2fe7f882d4bd734e2d140f67ab49d2
+c3e76dbcf706954bd9ada4e3a7fc50cf9294729f93b130ada3d3a4ae98cc7e7b6971
+X = 0x04879567d09560c02be565429036ed1d2fc3ca53f2eb6fadda4dba09eff3a0
+096f032f0e227207ebebe05e1e95de325dfffe579c8aae76054030e5435fd5298c75
+Y = 0x04b595a25588a2fba757195a756d289c191240296699f61fee8f15a7a741a4
+23d48bd44cf544b409bbe4262a8045051e734567548ba43b3117efd6fb03acf41aff
+Z = 0x047bb4661db7085d019cffa8495aba73d22f87ab8ba22e789477ef933b916f
+412863aeb2dbc8003e4f1c2193290338ea0c7d786d30ca47a48eea273375a0c72ca1
+V = 0x0417658e1e9707a29d429a4733d3bee703574aec222e781a6e7e5f5e504908
+11aabf28e112fee32a37c228df9b53e6220468a2f6f07427604d8917870ac965eec7
+TT = 0x0600000000000000636c69656e74060000000000000073657276657241000
+0000000000004879567d09560c02be565429036ed1d2fc3ca53f2eb6fadda4dba09e
+ff3a0096f032f0e227207ebebe05e1e95de325dfffe579c8aae76054030e5435fd52
+98c75410000000000000004b595a25588a2fba757195a756d289c191240296699f61
+fee8f15a7a741a423d48bd44cf544b409bbe4262a8045051e734567548ba43b3117e
+fd6fb03acf41aff4100000000000000047bb4661db7085d019cffa8495aba73d22f8
+7ab8ba22e789477ef933b916f412863aeb2dbc8003e4f1c2193290338ea0c7d786d3
+0ca47a48eea273375a0c72ca141000000000000000417658e1e9707a29d429a4733d
+3bee703574aec222e781a6e7e5f5e50490811aabf28e112fee32a37c228df9b53e62
+20468a2f6f07427604d8917870ac965eec720000000000000004f9e28322a64f9dc7
+a01b282cc51e2abc4f9ed568805ca84f4ed3ef806516cf8 
+Ka = 0xbf800062847c5182bf5c549b05ea6cce 
+Ke = 0xce9acf88ff9440777bda3e34fa4993cd 
+KcA = 0x73c6a5597096e99b8025172bb45b4a2f 
+KcB = 0x96a801673bd07b51d61fbaea03ef17cf 
+MAC(A) = 0xcab37c89192f9ad90ca5e6b8eadb130d313b51d24b7889e2536f7c800
+26e076a 
+MAC(B) = 0xf7076a78a3d16f0c62cb9e40bd1a91b68dee144b87016e2dae81c36e9
+73f3b2e 
+
+SPAKE2+(A='client', B='') 
+w0 = 0x4f9e28322a64f9dc7a01b282cc51e2abc4f9ed568805ca84f4ed3ef806516
+cf8 
+w1 = 0x8d73e4ca273859c873d809431d15f30e2b722007964e32699160b54fda3ee
+855 
+L = 0x0491bb1e6672e71ad80b17d13f7a72ca2fe7f882d4bd734e2d140f67ab49d2
+c3e76dbcf706954bd9ada4e3a7fc50cf9294729f93b130ada3d3a4ae98cc7e7b6971
+X = 0x0426fbedb3b9ccea93d609838dcc1d4baebdbb9c287763ed4cdb2d3cc76f78
+8d3388db3da1f63e945f3f1ba17f7b986ab9ed3170359ee406cbb40f3e3719453b15
+Y = 0x04d4960922990acb87809e734fed2c2ccb72fd26ed173e8207cdc6220073ac
+5017660788e96db275f6edf2ba400d4e090273c24dc907d80ff9cad7f42fd9f79c3f
+Z = 0x0421996ff4d9c05b2389ae05118c519679df5d6de258b31f2a17da7604c8e3
+c17bb3c4aae2ae4217951aa82144cb8b677be8061f28893f70216c1e11ba2bacd50d
+V = 0x04729f7c6c5bd68310345b1a10b84ea7db64c70441da2255992208b7a8e0b3
+9d4f0e634acf7d440b4552a41df291ac6a409f8cf5a47cec9fed5f85fea1241379a4
+TT = 0x0600000000000000636c69656e7441000000000000000426fbedb3b9ccea9
+3d609838dcc1d4baebdbb9c287763ed4cdb2d3cc76f788d3388db3da1f63e945f3f1
+ba17f7b986ab9ed3170359ee406cbb40f3e3719453b15410000000000000004d4960
+922990acb87809e734fed2c2ccb72fd26ed173e8207cdc6220073ac5017660788e96
+db275f6edf2ba400d4e090273c24dc907d80ff9cad7f42fd9f79c3f4100000000000
+0000421996ff4d9c05b2389ae05118c519679df5d6de258b31f2a17da7604c8e3c17
+bb3c4aae2ae4217951aa82144cb8b677be8061f28893f70216c1e11ba2bacd50d410
+000000000000004729f7c6c5bd68310345b1a10b84ea7db64c70441da2255992208b
+7a8e0b39d4f0e634acf7d440b4552a41df291ac6a409f8cf5a47cec9fed5f85fea12
+41379a420000000000000004f9e28322a64f9dc7a01b282cc51e2abc4f9ed568805c
+a84f4ed3ef806516cf8 
+Ka = 0xfd19104b836b0ba9dfaaeab88610be57 
+Ke = 0x90337374f974f673707de5ba1b98e5b8 
+KcA = 0x2e10249c566677c8826b48ad10b19bb5 
+KcB = 0x4fcaf8fd0bfcaeeabb9d6f48e264e4a3 
+MAC(A) = 0xaaef200ea5f5c41e1fdb9b3455dde715cd8aa96f8afd3274f7159c3c5
+4887f2c 
+MAC(B) = 0x926eadbf4b720b46ea622d7100e0013eb24d1591496846a604cf90c14
+46fe0e4 
+
+SPAKE2+(A='', B='server') 
+w0 = 0x4f9e28322a64f9dc7a01b282cc51e2abc4f9ed568805ca84f4ed3ef806516
+cf8 
+w1 = 0x8d73e4ca273859c873d809431d15f30e2b722007964e32699160b54fda3ee
+855 
+L = 0x0491bb1e6672e71ad80b17d13f7a72ca2fe7f882d4bd734e2d140f67ab49d2
+c3e76dbcf706954bd9ada4e3a7fc50cf9294729f93b130ada3d3a4ae98cc7e7b6971
+X = 0x0463a7531acd204e7d83ac6562278d7ced01a715eff937a25520bd2220c626
+33db0ea510591c5cd23159a7a97181ec24433aac6e628f16d42c455fcae668411e34
+Y = 0x0433625217e2ccc0c545126f756d999c16df68b14b73b3fe473593c1d3a0d7
+287b43b353177806c641588ec969852b56b17190d6ebe80313de74e5eee0c1403025
+Z = 0x049ef5ea46e8ca42f3e822c598858ca347bf19cc74a8a1fbfd836ec4d77bee
+7f0cd4d42f4f817caa3360c918d2538d7c96de5db47a72949ca2888d02c18ea6f92b
+V = 0x0408a70fc9dca87b70a7d4a074bdcca0222806f0caa0542d8d62aecf535ea8
+ffbc5e48419c5127a0f7f03685013c09d22f797523d26e7db159fecaccebc54ed2a7
+TT = 0x060000000000000073657276657241000000000000000463a7531acd204e7
+d83ac6562278d7ced01a715eff937a25520bd2220c62633db0ea510591c5cd23159a
+7a97181ec24433aac6e628f16d42c455fcae668411e3441000000000000000433625
+217e2ccc0c545126f756d999c16df68b14b73b3fe473593c1d3a0d7287b43b353177
+806c641588ec969852b56b17190d6ebe80313de74e5eee0c14030254100000000000
+000049ef5ea46e8ca42f3e822c598858ca347bf19cc74a8a1fbfd836ec4d77bee7f0
+cd4d42f4f817caa3360c918d2538d7c96de5db47a72949ca2888d02c18ea6f92b410
+00000000000000408a70fc9dca87b70a7d4a074bdcca0222806f0caa0542d8d62aec
+f535ea8ffbc5e48419c5127a0f7f03685013c09d22f797523d26e7db159fecaccebc
+54ed2a720000000000000004f9e28322a64f9dc7a01b282cc51e2abc4f9ed568805c
+a84f4ed3ef806516cf8 
+Ka = 0x5c85900898b2079c9de09ebef63cebd1 
+Ke = 0x13c812476859e909682c3be7436bfef0 
+KcA = 0x77bd636ab9bf153339c5724ee04f87a7 
+KcB = 0x194325b27d7c291c94a689ddafeaaa3c 
+MAC(A) = 0x3bb61248a1fd2946743314848fc501eb3455eb113bd8966e200de14d5
+e412688 
+MAC(B) = 0x3e7912bd2a85a1f56d36fbb16de29834b000d49e50d4c17f992942ee5
+9255f1e 
+
+SPAKE2+(A='', B='') 
+w0 = 0x4f9e28322a64f9dc7a01b282cc51e2abc4f9ed568805ca84f4ed3ef806516
+cf8 
+w1 = 0x8d73e4ca273859c873d809431d15f30e2b722007964e32699160b54fda3ee
+855 
+L = 0x0491bb1e6672e71ad80b17d13f7a72ca2fe7f882d4bd734e2d140f67ab49d2
+c3e76dbcf706954bd9ada4e3a7fc50cf9294729f93b130ada3d3a4ae98cc7e7b6971
+X = 0x04f60f506cfa07506d4bfd2b3f56038b1c001fe6826374122c30e914747eab
+647988702cc70210eb2aa625e603d56961af16ec543ee3d4d2cb90d6fe2f3c1d1180
+Y = 0x046898fafef34fff9936217608151af08313305cf8e6f9add10d721c04a018
+607f5b5aca327e150cd5d588de83e46491ec766e2cf87da9fb07dc3745c0630b03bb
+Z = 0x042adeeea1417cc6c592fef772da8ba0f3aea69a5fb15923d0e9ae7c3301c7
+ff87e9ff9fba292ad410e4af71770858e9a314f1deb75f77bde276d3cc8b45ffd70c
+V = 0x04845c130c8c20865828e21ed3400abea726b07fdeb7533fa6017accc37e0b
+e4922241dad44846112e42bee999501fdb4d09fc798e4677d403d10bfa862928584e
+TT = 0x410000000000000004f60f506cfa07506d4bfd2b3f56038b1c001fe682637
+4122c30e914747eab647988702cc70210eb2aa625e603d56961af16ec543ee3d4d2c
+b90d6fe2f3c1d11804100000000000000046898fafef34fff9936217608151af0831
+3305cf8e6f9add10d721c04a018607f5b5aca327e150cd5d588de83e46491ec766e2
+cf87da9fb07dc3745c0630b03bb4100000000000000042adeeea1417cc6c592fef77
+2da8ba0f3aea69a5fb15923d0e9ae7c3301c7ff87e9ff9fba292ad410e4af7177085
+8e9a314f1deb75f77bde276d3cc8b45ffd70c410000000000000004845c130c8c208
+65828e21ed3400abea726b07fdeb7533fa6017accc37e0be4922241dad44846112e4
+2bee999501fdb4d09fc798e4677d403d10bfa862928584e20000000000000004f9e2
+8322a64f9dc7a01b282cc51e2abc4f9ed568805ca84f4ed3ef806516cf8 
+Ka = 0x850a18a77b14ef5e71b4a239413630a8 
+Ke = 0x4454819282b3e886a7e65b7b0de7cc62 
+KcA = 0x05df6196c12d6203768c73d875e2bfc5 
+KcB = 0xb58e61c322f685add02c125767e4fbb7 
+MAC(A) = 0x33e50d29f8eacc67bfdab4a6c46c88d75ac3308416c64dfbb0d7fb1c0
+feda5b0 
+MAC(B) = 0x55434e5e501ad2d476aa1ae334ef27ba437a5dea87683defac575a63b
+548ca64 
+]]></artwork></figure>
+      </section>
     </section>
   </back>
 </rfc>


### PR DESCRIPTION
- Add SPAKE2 and SPAKE2+ test vectors.
- Clarify protocol flow.
- Align w0/w1 computation with SPAKE2 in the absence of identities.
- Derive authentication key before encryption key.
- Remove MHF ciphersuite parameter.
- Fix typos.