### PR TITLE
Some Typo Fixes, Suggestions, etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,7 @@
-all:
-	xml2rfc draft-irtf-cfrg-spake2.xml
+all: draft-irtf-cfrg-spake2.txt draft-irtf-cfrg-spake2.html
+
+draft-irtf-cfrg-spake2.txt: draft-irtf-cfrg-spake2.xml
+	xml2rfc --text draft-irtf-cfrg-spake2.xml
+
+draft-irtf-cfrg-spake2.html: draft-irtf-cfrg-spake2.xml
+	xml2rfc --html draft-irtf-cfrg-spake2.xml

--- a/draft-irtf-cfrg-spake2.xml
+++ b/draft-irtf-cfrg-spake2.xml
@@ -162,16 +162,33 @@
           the exchange. The transcript TT is encoded as follows:</t>
 
         <figure><artwork><![CDATA[
-	TT = len(A) || A || len(B) || B || len(S) || S 
-          || len(T) || T || len(K) || K || len(w) || w
+        TT = len(A) || A
+          || len(B) || B
+          || len(S) || S
+          || len(T) || T
+          || len(K) || K
+          || len(w) || w
         ]]></artwork></figure>
 
         <t>If an identity is absent, it is omitted from the transcript entirely. For example,
-          if both A and B are absent, then TT = len(S) || S || len(T) || T || len(K) || K || len(w) || w.
-          Likewise, if only A is absent, TT = len(B) || B || len(S) || S || len(T) || T || len(K) || K || len(w) || w.
-          This must only be done for applications in which identities are implicit. Otherwise,
-          the protocol risks Unknown Key Share attacks (discussion of Unknown Key Share attacks
-          in a specific protocol is given in <xref target="I-D.ietf-mmusic-sdp-uks"/>.</t>
+          if both A and B are absent, then: 
+        <figure><artwork><![CDATA[
+        TT = len(S)  || S
+           || len(T) || T
+           || len(K) || K
+           || len(w) || w
+        ]]></artwork></figure>
+        Likewise, if only A is absent, then:
+        <figure><artwork><![CDATA[
+        TT = len(B)  || B
+           || len(S) || S
+           || len(T) || T
+           || len(K) || K
+           || len(w) || w
+        ]]></artwork></figure>
+        This must only be done for applications in which identities are implicit. Otherwise,
+        the protocol risks Unknown Key Share attacks (discussion of Unknown Key Share attacks
+        in a specific protocol is given in <xref target="I-D.ietf-mmusic-sdp-uks"/>.</t>
 
         <t>Upon completion of this protocol, A and B compute shared secrets Ke, KcA, and KcB as
             specified in <xref target="keys"/>. A MUST send B a key confirmation message
@@ -211,9 +228,9 @@
       To avoid concerns that an attacker needs to solve a single ECDH instance to break the authentication of SPAKE2, a variant
       based on using <xref target="I-D.irtf-cfrg-hash-to-curve"/> is also presented. In this variant, M and N are computed as follows:
         <figure><artwork><![CDATA[
-	M = h2c(Hash("M for SPAKE2" || len(A) || A || len(B) || B))
-	N = h2c(Hash("N for SPAKE2" || len(A) || A || len(B) || B))
-		]]></artwork></figure>
+        M = h2c(Hash("M for SPAKE2" || len(A) || A || len(B) || B))
+        N = h2c(Hash("N for SPAKE2" || len(A) || A || len(B) || B))
+                ]]></artwork></figure>
 		In addition M and N may be equal to have a symmetric variant. The security of these variants is examined in <xref target="MNVAR"/>.
      </t>
     </section>

--- a/draft-irtf-cfrg-spake2.xml
+++ b/draft-irtf-cfrg-spake2.xml
@@ -216,8 +216,8 @@
             data AAD, is as follows.</t>
 
         <figure><artwork><![CDATA[
-        TT  -> Hash(TT) = Ka || Ke
-        AAD -> KDF(nil, Ka, "ConfirmationKeys" || AAD) = KcA || KcB
+    TT  -> Hash(TT) = Ka || Ke
+    AAD -> KDF(nil, Ka, "ConfirmationKeys" || AAD) = KcA || KcB
         ]]></artwork></figure>
 
         <t>A and B output Ke as the shared secret from the protocol. Ka and its derived keys are not
@@ -228,8 +228,8 @@
       To avoid concerns that an attacker needs to solve a single ECDH instance to break the authentication of SPAKE2, a variant
       based on using <xref target="I-D.irtf-cfrg-hash-to-curve"/> is also presented. In this variant, M and N are computed as follows:
         <figure><artwork><![CDATA[
-        M = h2c(Hash("M for SPAKE2" || len(A) || A || len(B) || B))
-        N = h2c(Hash("N for SPAKE2" || len(A) || A || len(B) || B))
+    M = h2c(Hash("M for SPAKE2" || len(A) || A || len(B) || B))
+    N = h2c(Hash("N for SPAKE2" || len(A) || A || len(B) || B))
                 ]]></artwork></figure>
 		In addition M and N may be equal to have a symmetric variant. The security of these variants is examined in <xref target="MNVAR"/>.
      </t>

--- a/draft-irtf-cfrg-spake2.xml
+++ b/draft-irtf-cfrg-spake2.xml
@@ -209,7 +209,12 @@
     <section title="Per-User M and N">
       <t>
       To avoid concerns that an attacker needs to solve a single ECDH instance to break the authentication of SPAKE2, a variant
-      based on using <xref target="I-D.irtf-cfrg-hash-to-curve"/> is also presented. In this variant M=h2c(HASH(A, B, "M for SPAKE2"), N=h2c(HASH(A, B, "N for SPAKE2")). In addition M and N may be equal to have a symmetric variant. The security of these variants is examined in <xref target="MNVAR"/>
+      based on using <xref target="I-D.irtf-cfrg-hash-to-curve"/> is also presented. In this variant, M and N are computed as follows:
+        <figure><artwork><![CDATA[
+	M = h2c(Hash("M for SPAKE2" || len(A) || A || len(B) || B))
+	N = h2c(Hash("N for SPAKE2" || len(A) || A || len(B) || B))
+		]]></artwork></figure>
+		In addition M and N may be equal to have a symmetric variant. The security of these variants is examined in <xref target="MNVAR"/>.
      </t>
     </section>
     <section title="Ciphersuites" anchor="Ciphersuites">

--- a/draft-irtf-cfrg-spake2.xml
+++ b/draft-irtf-cfrg-spake2.xml
@@ -103,7 +103,7 @@
           this list would ensure that both parties agree upon the same set of supported protocols
           and therefore prevent downgrade attacks. We also assume A and B share an integer w;
           typically w = MHF(pw) mod p, for a user-supplied password pw.
-          Standards such NIST.SP.800-56Ar3 suggest taking mod p of a
+          Standards such as NIST.SP.800-56Ar3 suggest taking mod p of a
           hash value that is 64 bits longer than that needed to represent p to remove
           statistical bias introduced by the modulation. Protocols using this specification must define
           the method used to compute w: it may be necessary to carry out various
@@ -114,7 +114,7 @@
       </section>
 
       <section title="Protocol Flow" anchor="flow">
-        <t>SPAKE2 is a one round protocols to establish a shared secret with an 
+        <t>SPAKE2 is a one round protocol to establish a shared secret with an
           additional round for key confirmation. Prior to invocation, A and B are provisioned with
           information such as the input password needed to run the protocol. 
           During the first round, A sends a public share pA 
@@ -122,7 +122,7 @@
           used to produce encryption and authentication keys. The latter are used during the second
           round for key confirmation. (<xref target="keys"/> details the key derivation and 
           confirmation steps.) In particular, A sends a key confirmation message cA to B, and B responds
-          with its own key confirmation messgage cB. Both parties MUST NOT consider the protocol complete
+          with its own key confirmation message cB. Both parties MUST NOT consider the protocol complete
           prior to receipt and validation of these key confirmation messages.</t>
 
         <t>This sample trace is shown below.</t>
@@ -206,7 +206,7 @@
         <t>A and B output Ke as the shared secret from the protocol. Ka and its derived keys are not
             used for anything except key confirmation.</t>
     </section>
-    <section title="Per-user M and N">
+    <section title="Per-User M and N">
       <t>
       To avoid concerns that an attacker needs to solve a single ECDH instance to break the authentication of SPAKE2, a variant
       based on using <xref target="I-D.irtf-cfrg-hash-to-curve"/> is also presented. In this variant M=h2c(HASH(A, B, "M for SPAKE2"), N=h2c(HASH(A, B, "N for SPAKE2")). In addition M and N may be equal to have a symmetric variant. The security of these variants is examined in <xref target="MNVAR"/>
@@ -220,7 +220,7 @@
             P-256 that uses SHA256 along with HKDF <xref target="RFC5869"/> and HMAC <xref target="RFC2104"/>
             for G, Hash, KDF, and MAC functions, respectively.</t>
 
-            <texttable anchor="spake2_ciphersuites" title="SPAKE2(+) Ciphersuites">
+            <texttable anchor="spake2_ciphersuites" title="SPAKE2 Ciphersuites">
                 <ttcol align='center'>G</ttcol>
                 <ttcol align='center'>Hash</ttcol>
                 <ttcol align='center'>KDF</ttcol>

--- a/draft-irtf-cfrg-spake2.xml
+++ b/draft-irtf-cfrg-spake2.xml
@@ -154,10 +154,10 @@
         because it has received it, and likewise B knows T. The
         multiplication by h prevents small subgroup confinement
         attacks by computing a unique value in the quotient
-        group. (Any text on abstract algebra explains this notion.)</t>
+        group. This is a common mitigation against this kind of attack.</t>
 
         <t>K is a shared value, though it MUST NOT be used as a shared secret.
-          Both A and B must derive two shared secrets from the protocol transcript, including K.
+          Both A and B must derive two shared secrets from the protocol transcript.
           This prevents man-in-the-middle attackers from inserting themselves into
           the exchange. The transcript TT is encoded as follows:</t>
 
@@ -188,7 +188,7 @@
         ]]></artwork></figure>
         This must only be done for applications in which identities are implicit. Otherwise,
         the protocol risks Unknown Key Share attacks (discussion of Unknown Key Share attacks
-        in a specific protocol is given in <xref target="I-D.ietf-mmusic-sdp-uks"/>.</t>
+        in a specific protocol is given in <xref target="I-D.ietf-mmusic-sdp-uks"/>).</t>
 
         <t>Upon completion of this protocol, A and B compute shared secrets Ke, KcA, and KcB as
             specified in <xref target="keys"/>. A MUST send B a key confirmation message
@@ -201,9 +201,9 @@
 
     </section>
     <section title="Key Schedule and Key Confirmation" anchor="keys">
-        <t>The protocol transcript TT, as defined in Section <xref target="spake2"/>, is unique and secret to A and B. Both parties use TT to
-            derive shared symmetric secrets Ke and Ka as Ke || Ka = Hash(TT). The length of each
-            key is equal to half of the digest output, e.g., |Ke| = |Ka| = 128 bits for SHA-256.</t>
+        <t>The protocol transcript TT, as defined in Section <xref target="spake2"/>, is unique and secret to A and B.
+            Both parties use TT to derive shared symmetric secrets Ke and Ka as Ke || Ka = Hash(TT), with |Ke| = |Ka|.
+            The length of each key is equal to half of the digest output, e.g., 128 bits for SHA-256.</t>
 
         <t>Both endpoints use Ka to derive subsequent MAC keys for key confirmation messages.
             Specifically, let KcA and KcB be the MAC keys used by A and B, respectively.

--- a/draft-irtf-cfrg-spake2.xml
+++ b/draft-irtf-cfrg-spake2.xml
@@ -157,7 +157,7 @@
         group. (Any text on abstract algebra explains this notion.)</t>
 
         <t>K is a shared value, though it MUST NOT be used as a shared secret.
-          Both A and B must derive two shared secrets from K and the protocol transcript.
+          Both A and B must derive two shared secrets from the protocol transcript, including K.
           This prevents man-in-the-middle attackers from inserting themselves into
           the exchange. The transcript TT is encoded as follows:</t>
 


### PR DESCRIPTION
Hi!

I am Jan, and this PR was assembled by Ram (@vu3rdd) and me. We are with @LeastAuthority, where we help out with https://github.com/warner/magic-wormhole, a tool that uses SPAKE2. Part of this is trying to find ways to aid the standardization efforts.

This PR mostly contains typo fixes, clarifications and attempts to improve formatting and wording in some places. One change of actual content is in the per-user M and N section, where we moved the string constant to the start of the hash and length-prefixed the two party identities A and B.

We hope this contribution is welcome! If you are interested, we have some nitpicks we can share, but didn't want to open the discussion with :)

(oh yes, the first commit was salvaged from a different PR to get things building again)